### PR TITLE
Command groups

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -5,7 +5,6 @@ const getFiles = require("./getFiles");
 const remind = require("./remind");
 const verify = require("./verify");
 const { handleIdentify } = require("./utils/TLE");
-const { hasRole } = require("./utils/guildMemberHandlers");
 const getPrefix = require("./utils/getCommandPrefix");
 const reactionHandler = require("./utils/reactionHandler");
 
@@ -98,24 +97,13 @@ bot.on("message", async (message) => {
     !bot.commands.has(command) ||
     bot.commands.get(command).parentName !== undefined
   ) {
-    bot.commands.get("invalid").execute(message, args, prefix);
+    bot.commands.get("invalid").execute(bot, message, args, prefix);
     return;
-  }
-
-  // this won't work if the subcommand requires "Admin" role
-  if (bot.commands.get(command).permission === "*") {
-    const admin = await hasRole(bot, message.author.id, "Admin");
-    if (admin === false) {
-      message.reply("you do not have permission to run this command.");
-      return;
-    }
   }
 
   // execute the command
   try {
-    if (command === "help")
-      await bot.commands.get(command).execute(bot, message, args, prefix);
-    else await bot.commands.get(command).execute(message, args, prefix);
+    await bot.commands.get(command).execute(bot, message, args, prefix);
   } catch (error) {
     bot.channels.cache.get(process.env.ERROR_LOG_CHANNEL).send(error.stack);
     message.reply("There was some error in executing that command! 🙁");

--- a/commands/events/add.js
+++ b/commands/events/add.js
@@ -60,12 +60,16 @@ const compute = (args) => {
   return flag ? true : false;
 };
 
+const parentName = "events";
+const name = "add";
+
 module.exports = {
-  name: "addevent",
+  parentName,
+  name,
   permission: "*",
   description: "Add an event",
   usage: (prefix) => `\`\`\`
-${prefix}addevent
+${prefix}${parentName} ${name}
 
 Format:
 date: DD/MM/YYYY
@@ -76,7 +80,7 @@ venue: ...
   execute: async (message, args, prefix) => {
     if (!compute(args)) {
       message.channel.send(
-        `Wrong format! Use ${prefix}help addevent to know about usage.`
+        `Wrong format! Use ${prefix}help ${parentName} ${name} to know about usage.`
       );
       return;
     }

--- a/commands/events/add.js
+++ b/commands/events/add.js
@@ -1,5 +1,6 @@
 const mongo = require("../../mongo");
 const Event = require("../../models/event.model");
+const { hasRole } = require("../../utils/guildMemberHandlers");
 
 // The date is entered according to IST
 // but the bot will consider it as UTC
@@ -77,7 +78,13 @@ time: HH:MM (24 hr)
 title: ...
 venue: ...
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
+    const admin = await hasRole(bot, message.author.id, "Admin");
+    if (admin === false) {
+      message.reply("you do not have permission to run this command.");
+      return;
+    }
+
     if (!compute(args)) {
       message.channel.send(
         `Wrong format! Use ${prefix}help ${parentName} ${name} to know about usage.`

--- a/commands/events/delete.js
+++ b/commands/events/delete.js
@@ -1,5 +1,6 @@
 const mongo = require("../../mongo");
 const Event = require("../../models/event.model");
+const { hasRole } = require("../../utils/guildMemberHandlers");
 
 const parentName = "events";
 const name = "delete";
@@ -14,7 +15,13 @@ ${prefix}${parentName} ${name}
 
 Pass the event S.No. according to ${prefix}${parentName} showevents to delete that particular event.
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
+    const admin = await hasRole(bot, message.author.id, "Admin");
+    if (admin === false) {
+      message.reply("you do not have permission to run this command.");
+      return;
+    }
+
     if (args.length !== 1) {
       message.channel.send(
         `Wrong format! Use ${prefix}help ${parentName} ${name} to know about usage.`

--- a/commands/events/delete.js
+++ b/commands/events/delete.js
@@ -1,19 +1,23 @@
 const mongo = require("../../mongo");
 const Event = require("../../models/event.model");
 
+const parentName = "events";
+const name = "delete";
+
 module.exports = {
-  name: "deleteevent",
+  parentName,
+  name,
   permission: "*",
   description: "Delete an event",
   usage: (prefix) => `\`\`\`
-${prefix}deleteevent
+${prefix}${parentName} ${name}
 
-Pass the event S.No. according to ${prefix}showevents to delete that particular event.
+Pass the event S.No. according to ${prefix}${parentName} showevents to delete that particular event.
 \`\`\``,
   execute: async (message, args, prefix) => {
     if (args.length !== 1) {
       message.channel.send(
-        `Wrong format! Use ${prefix}help deleteevent to know about usage.`
+        `Wrong format! Use ${prefix}help ${parentName} ${name} to know about usage.`
       );
       return;
     }

--- a/commands/events/events.js
+++ b/commands/events/events.js
@@ -1,0 +1,6 @@
+const { getCommandObj } = require("../../utils/subCommandHandlers");
+
+const name = "events";
+const description = "Commands related to events";
+
+module.exports = getCommandObj(name, description);

--- a/commands/events/events.js
+++ b/commands/events/events.js
@@ -2,5 +2,6 @@ const { getCommandObj } = require("../../utils/subCommandHandlers");
 
 const name = "events";
 const description = "Commands related to events";
+const isParent = true;
 
-module.exports = getCommandObj(name, description);
+module.exports = getCommandObj(name, description, isParent);

--- a/commands/events/next.js
+++ b/commands/events/next.js
@@ -30,7 +30,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to view the next upcoming event.
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
     await mongo().then(async (mongoose) => {
       try {
         await Event.find()

--- a/commands/events/next.js
+++ b/commands/events/next.js
@@ -18,11 +18,15 @@ const compute = (eventObject) => {
   return nextEvent;
 };
 
+const parentName = "events";
+const name = "next";
+
 module.exports = {
-  name: "nextevent",
+  parentName,
+  name,
   description: "Show next event",
   usage: (prefix) => `\`\`\`
-${prefix}nextevent
+${prefix}${parentName} ${name}
 
 Type the command to view the next upcoming event.
 \`\`\``,

--- a/commands/events/show.js
+++ b/commands/events/show.js
@@ -32,11 +32,15 @@ const compute = (eventObjects) => {
   return events;
 };
 
+const parentName = "events";
+const name = "show";
+
 module.exports = {
-  name: "showevents",
+  parentName,
+  name,
   description: "Show all events",
   usage: (prefix) => `\`\`\`
-${prefix}showevents
+${prefix}${parentName} ${name}
 
 Type the command to view all the events.
 \`\`\``,

--- a/commands/events/show.js
+++ b/commands/events/show.js
@@ -44,7 +44,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to view all the events.
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
     await mongo().then(async (mongoose) => {
       await Event.find()
         .sort("date")

--- a/commands/links/cfgroup.js
+++ b/commands/links/cfgroup.js
@@ -12,7 +12,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to get the link to the CodeForces Group.
 \`\`\``,
-  execute(message, args, prefix) {
+  execute: (bot, message, args, prefix) => {
     const github = new Discord.MessageEmbed()
       .setTitle("Join our CodeForces Group")
       .setURL("https://codeforces.com/group/IUJm1OmeBo");

--- a/commands/links/cfgroup.js
+++ b/commands/links/cfgroup.js
@@ -1,10 +1,14 @@
 const Discord = require("discord.js");
 
+const parentName = "links";
+const name = "cfgroup";
+
 module.exports = {
-  name: "cfgroup",
+  parentName,
+  name,
   description: "CF Group",
   usage: (prefix) => `\`\`\`
-${prefix}cfgroup
+${prefix}${parentName} ${name}
 
 Type the command to get the link to the CodeForces Group.
 \`\`\``,

--- a/commands/links/facebook.js
+++ b/commands/links/facebook.js
@@ -12,7 +12,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to get the link to the Facebook Group.
 \`\`\``,
-  execute(message, args, prefix) {
+  execute: (bot, message, args, prefix) => {
     const facebook = new Discord.MessageEmbed()
       .setTitle("Join us on Facebook")
       .setURL("https://www.facebook.com/groups/jiit.knuth");

--- a/commands/links/facebook.js
+++ b/commands/links/facebook.js
@@ -1,10 +1,14 @@
 const Discord = require("discord.js");
 
+const parentName = "links";
+const name = "facebook";
+
 module.exports = {
-  name: "facebook",
+  parentName,
+  name,
   description: "Facebook Group",
   usage: (prefix) => `\`\`\`
-${prefix}facebook
+${prefix}${parentName} ${name}
 
 Type the command to get the link to the Facebook Group.
 \`\`\``,

--- a/commands/links/github.js
+++ b/commands/links/github.js
@@ -1,10 +1,14 @@
 const Discord = require("discord.js");
 
+const parentName = "links";
+const name = "github";
+
 module.exports = {
-  name: "github",
+  parentName,
+  name,
   description: "Github Org",
   usage: (prefix) => `\`\`\`
-${prefix}github
+${prefix}${parentName} ${name}
 
 Type the command to get the link to the GitHub organisation.
 \`\`\``,

--- a/commands/links/github.js
+++ b/commands/links/github.js
@@ -12,7 +12,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to get the link to the GitHub organisation.
 \`\`\``,
-  execute(message, args, prefix) {
+  execute: (bot, message, args, prefix) => {
     const github = new Discord.MessageEmbed()
       .setTitle("Take a look at our GitHub organisation")
       .setURL("https://github.com/Knuth-Programming-Hub");

--- a/commands/links/links.js
+++ b/commands/links/links.js
@@ -2,5 +2,6 @@ const { getCommandObj } = require("../../utils/subCommandHandlers");
 
 const name = "links";
 const description = "KPH's online presence";
+const isParent = true;
 
-module.exports = getCommandObj(name, description);
+module.exports = getCommandObj(name, description, isParent);

--- a/commands/links/links.js
+++ b/commands/links/links.js
@@ -1,0 +1,6 @@
+const { getCommandObj } = require("../../utils/subCommandHandlers");
+
+const name = "links";
+const description = "KPH's online presence";
+
+module.exports = getCommandObj(name, description);

--- a/commands/links/telegram.js
+++ b/commands/links/telegram.js
@@ -12,7 +12,7 @@ ${prefix}${parentName} ${name}
 
 Type the command to get the link to the Telegram Group.
 \`\`\``,
-  execute(message, args, prefix) {
+  execute: (bot, message, args, prefix) => {
     const telegram = new Discord.MessageEmbed()
       .setTitle("Join our Telegram Group")
       .setURL("https://t.me/joinchat/LGo0IhZoPRjRjBJHJPf3OA");

--- a/commands/links/telegram.js
+++ b/commands/links/telegram.js
@@ -1,10 +1,14 @@
 const Discord = require("discord.js");
 
+const parentName = "links";
+const name = "telegram";
+
 module.exports = {
-  name: "telegram",
+  parentName,
+  name,
   description: "Telegram Group",
   usage: (prefix) => `\`\`\`
-${prefix}telegram
+${prefix}${parentName} ${name}
 
 Type the command to get the link to the Telegram Group.
 \`\`\``,

--- a/commands/misc/invalid.js
+++ b/commands/misc/invalid.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: "invalid",
   description: "Invalid Command",
-  execute(message, args, prefix) {
+  execute: (bot, message, args, prefix) => {
     message.channel.send(
       `Looks like that's an invalid command , Try ${prefix}help for reference.`
     );

--- a/commands/misc/paste.js
+++ b/commands/misc/paste.js
@@ -35,7 +35,7 @@ Format:
 ${prefix}paste <filename>
 <code>
 \`\`\``,
-  execute: async (message, recievedArgs, prefix) => {
+  execute: async (bot, message, recievedArgs, prefix) => {
     const args = String(message.content.trim());
 
     if (!compute(args, prefix)) {

--- a/commands/server/clearChannel.js
+++ b/commands/server/clearChannel.js
@@ -1,3 +1,5 @@
+const { hasRole } = require("../../utils/guildMemberHandlers");
+
 module.exports = {
   name: "clearchannel",
   permission: "*",
@@ -8,7 +10,12 @@ ${prefix}clearchannel
 Simply type the command to clear the messages of the current channel.
 Be very careful when using this command!
 \`\`\``,
-  execute: (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
+    const admin = await hasRole(bot, message.author.id, "Admin");
+    if (admin === false) {
+      message.reply("you do not have permission to run this command.");
+      return;
+    }
     message.channel.messages.fetch().then((res) => {
       message.channel.bulkDelete(res);
     });

--- a/commands/server/ranklist.js
+++ b/commands/server/ranklist.js
@@ -28,7 +28,7 @@ ${prefix}ranklist
 Format: ${prefix}ranklist [batch]
 You can enter multiple batches!
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
     for (let elem of args) elem = Number(elem);
 
     let filter = {};

--- a/commands/server/setPrefix.js
+++ b/commands/server/setPrefix.js
@@ -1,5 +1,6 @@
 const mongo = require("../../mongo");
 const prefixModel = require("../../models/prefix.model");
+const { hasRole } = require("../../utils/guildMemberHandlers");
 
 module.exports = {
   name: "setprefix",
@@ -11,7 +12,13 @@ ${prefix}setprefix
 Format:
 ${prefix}setprefix <command-prefix>
 \`\`\``,
-  execute: async (message, args, prefix) => {
+  execute: async (bot, message, args, prefix) => {
+    const admin = await hasRole(bot, message.author.id, "Admin");
+    if (admin === false) {
+      message.reply("you do not have permission to run this command.");
+      return;
+    }
+
     if (args.length >= 2) {
       message.channel.send(
         `Wrong format! Use ${prefix}help setprefix to know about usage.`

--- a/utils/subCommandHandlers.js
+++ b/utils/subCommandHandlers.js
@@ -30,13 +30,13 @@ const displayUsage = async (name, description, prefix) => {
   return str;
 };
 
-const executeSubCommand = async (name, message, args, prefix) => {
-  const subCommandName = args.shift().toLowerCase();
-
+const getSubCommand = async (name, args) => {
   let childrenPaths;
   await getChildren(name).then((files) => {
     childrenPaths = files;
   });
+
+  const subCommandName = args[0].toLowerCase();
 
   for (const file of childrenPaths) {
     let filePath = String(file);
@@ -45,13 +45,14 @@ const executeSubCommand = async (name, message, args, prefix) => {
 
     if (subCommandName === fileName) {
       const command = require(filePath);
-      command.execute(message, args, prefix);
-      break;
+      return command;
     }
   }
+
+  return null;
 };
 
-const getCommandObj = (name, description, message, args, prefix) => {
+const getCommandObj = (name, description) => {
   return {
     name,
     description,
@@ -60,7 +61,12 @@ const getCommandObj = (name, description, message, args, prefix) => {
       if (args.length === 0) {
         message.channel.send(await displayUsage(name, description, prefix));
       } else {
-        executeSubCommand(name, message, args, prefix);
+        const subCommand = await getSubCommand(name, args);
+        if (subCommand === null)
+          message.channel.send(
+            `Command not found! try ${prefix}help ${name} to view the available commands.`
+          );
+        else subCommand.execute(message, args, prefix);
       }
     },
   };
@@ -69,6 +75,6 @@ const getCommandObj = (name, description, message, args, prefix) => {
 module.exports = {
   getChildren,
   displayUsage,
-  executeSubCommand,
+  getSubCommand,
   getCommandObj,
 };

--- a/utils/subCommandHandlers.js
+++ b/utils/subCommandHandlers.js
@@ -58,7 +58,7 @@ const getCommandObj = (name, description, isParent) => {
     description,
     isParent,
     usage: async (prefix) => await displayUsage(name, description, prefix),
-    execute: async (message, args, prefix) => {
+    execute: async (bot, message, args, prefix) => {
       if (args.length === 0) {
         message.channel.send(await displayUsage(name, description, prefix));
       } else {
@@ -67,7 +67,10 @@ const getCommandObj = (name, description, isParent) => {
           message.channel.send(
             `Command not found! try ${prefix}help ${name} to view the available commands.`
           );
-        else subCommand.execute(message, args, prefix);
+        else {
+          args.splice(0, 1);
+          subCommand.execute(bot, message, args, prefix);
+        }
       }
     },
   };

--- a/utils/subCommandHandlers.js
+++ b/utils/subCommandHandlers.js
@@ -52,10 +52,11 @@ const getSubCommand = async (name, args) => {
   return null;
 };
 
-const getCommandObj = (name, description) => {
+const getCommandObj = (name, description, isParent) => {
   return {
     name,
     description,
+    isParent,
     usage: async (prefix) => await displayUsage(name, description, prefix),
     execute: async (message, args, prefix) => {
       if (args.length === 0) {

--- a/utils/subCommandHandlers.js
+++ b/utils/subCommandHandlers.js
@@ -1,0 +1,74 @@
+const getFiles = require("../getFiles");
+
+const getChildren = async (parentCommand) => {
+  const files = await getFiles(`./commands/${parentCommand}`);
+
+  const index = files.findIndex((elem) => elem.includes(`${parentCommand}.js`));
+  files.splice(index, 1);
+
+  return files;
+};
+
+const displayUsage = async (name, description, prefix) => {
+  let str = "```\n";
+  str += `\n${prefix}${name}\n${description}\n\n`;
+  str += "Commands:\n";
+
+  let childrenPaths;
+  await getChildren(name).then((files) => {
+    childrenPaths = files;
+  });
+
+  for (let path of childrenPaths) {
+    const command = require(path);
+    str += `\t${command.name}${
+      command.permission === undefined ? "" : command.permission
+    } : ${command.description}\n`;
+  }
+
+  str += "```";
+  return str;
+};
+
+const executeSubCommand = async (name, message, args, prefix) => {
+  const subCommandName = args.shift().toLowerCase();
+
+  let childrenPaths;
+  await getChildren(name).then((files) => {
+    childrenPaths = files;
+  });
+
+  for (const file of childrenPaths) {
+    let filePath = String(file);
+    let fileName = filePath.replace(/^.*[\\\/]/, "");
+    fileName = fileName.substring(0, fileName.length - 3).toLowerCase();
+
+    if (subCommandName === fileName) {
+      const command = require(filePath);
+      command.execute(message, args, prefix);
+      break;
+    }
+  }
+};
+
+const getCommandObj = (name, description, message, args, prefix) => {
+  return {
+    name,
+    description,
+    usage: async (prefix) => await displayUsage(name, description, prefix),
+    execute: async (message, args, prefix) => {
+      if (args.length === 0) {
+        message.channel.send(await displayUsage(name, description, prefix));
+      } else {
+        executeSubCommand(name, message, args, prefix);
+      }
+    },
+  };
+};
+
+module.exports = {
+  getChildren,
+  displayUsage,
+  executeSubCommand,
+  getCommandObj,
+};


### PR DESCRIPTION
Closes #31 

Structure: 
  - For a command group folder, there would be a parent command that would be used to access the children commands. 
  - Eg: .commands/events/ will have events.js which will call the children commands - add.js, delete.js, show.js, next.js - according to the input.
  - This has been done to minimize changes to the existing codebase and make it easy to create new command groups later. 

Summary:
- subCommandHandlers to link parent command to children commands
- `<command> <subcommand>` and `help <command> <subcommand>` formats established
- Hard-coding minimized in command-error messages
- Client passed to each command's execute() as argument

Screenshots:
<details>
<summary>click to expand</summary>
<img src=https://user-images.githubusercontent.com/45938556/109922669-bde11f80-7ce3-11eb-8628-37df31adfca1.png>
<img src=https://user-images.githubusercontent.com/45938556/109922947-24fed400-7ce4-11eb-8b6c-0d6875faa54f.png>
<img src=https://user-images.githubusercontent.com/45938556/109922895-13b5c780-7ce4-11eb-8ddc-b484a8655378.png>
<img src=https://user-images.githubusercontent.com/45938556/109923702-28468f80-7ce5-11eb-84b4-1e1506547bb7.png>
</details>